### PR TITLE
feat: save extension logs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Kwork Metrics Tracker",
   "version": "1.0",
   "description": "Автоматический сбор метрик с Kwork",
-  "permissions": ["storage", "alarms", "scripting", "tabs"],
+  "permissions": ["storage", "alarms", "scripting", "tabs", "downloads"],
   "background": {
     "service_worker": "background.js"
   },

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,5 @@
 import type { Metrics } from "./types";
+import { log } from "./logger";
 
 chrome.runtime.onInstalled.addListener(async () => {
   // Set default interval to 1 minute if not set
@@ -9,12 +10,12 @@ chrome.runtime.onInstalled.addListener(async () => {
   chrome.alarms.clear("fetchMetrics");
   chrome.alarms.create("fetchMetrics", { periodInMinutes: interval });
   
-  console.log(`Auto-collect set to ${interval} minutes`);
+  await log(`Auto-collect set to ${interval} minutes`);
 });
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === "fetchMetrics") {
-    console.log('Auto-collecting metrics...');
+    await log('Auto-collecting metrics...');
     
     const tab = await chrome.tabs.create({ 
       url: "https://kwork.ru/manage_kworks", 
@@ -47,7 +48,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
         lastUpdated: new Date().toISOString()
       });
       
-      console.log('Metrics saved:', message.data);
+      log('Metrics saved: ' + JSON.stringify(message.data));
     });
   }
   
@@ -56,6 +57,6 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     const newInterval = message.interval;
     chrome.alarms.clear("fetchMetrics");
     chrome.alarms.create("fetchMetrics", { periodInMinutes: newInterval });
-    console.log(`Interval updated to ${newInterval} minutes`);
+    log(`Interval updated to ${newInterval} minutes`);
   }
 });

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,3 +1,5 @@
+import { log } from "./logger";
+
 function getMetrics() {
   // More robust selectors for Kwork dashboard
   let views = "0";
@@ -62,7 +64,7 @@ function getMetrics() {
     competition = competitionElement.textContent?.trim() || "N/A";
   }
 
-  console.log('Extracted metrics:', { views, sales, earned, competition });
+  log('Extracted metrics: ' + JSON.stringify({ views, sales, earned, competition }));
 
   return {
     date: new Date().toISOString(),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,27 @@
+export async function log(message: string) {
+  console.log(message);
+  if (!chrome?.storage?.local) return;
+  const { logs = [] } = await chrome.storage.local.get(['logs']);
+  logs.push({ time: new Date().toISOString(), message });
+  await chrome.storage.local.set({ logs });
+}
+
+export async function downloadLogs() {
+  if (!chrome?.storage?.local || !chrome.downloads) return;
+  const { logs = [] } = await chrome.storage.local.get(['logs']);
+  const content = logs.map((l: any) => `[${l.time}] ${l.message}`).join('\n');
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  chrome.downloads.download({
+    url,
+    filename: `kwork_logs_${new Date().toISOString().split('T')[0]}.log`,
+    saveAs: true
+  }, () => {
+    URL.revokeObjectURL(url);
+  });
+}
+
+export async function clearLogs() {
+  if (!chrome?.storage?.local) return;
+  await chrome.storage.local.remove(['logs']);
+}

--- a/src/popup/App.svelte
+++ b/src/popup/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import Chart from "./Chart.svelte";
+  import { downloadLogs } from "../logger";
 
   interface Metrics {
     date: string;
@@ -225,6 +226,14 @@
     }
     return `${collectInterval}м`;
   }
+
+  function exportLogs() {
+    if (typeof chrome === "undefined") {
+      console.warn("Chrome APIs are not available.");
+      return;
+    }
+    downloadLogs();
+  }
 </script>
 
 <div class="container">
@@ -385,6 +394,9 @@
         </button>
         <button class="btn btn-export" on:click={copyToClipboard}>
           📋 Копировать
+        </button>
+        <button class="btn btn-export" on:click={exportLogs}>
+          🪵 Логи
         </button>
       </div>
       <button class="btn btn-danger" on:click={clearAllData}>


### PR DESCRIPTION
## Summary
- capture extension events with new logging utility and persist them to storage
- add button to export logs as a file for easier debugging
- enable downloads permission for log export

## Testing
- `npm test` *(fails: Missing script)*
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688f59bfabbc8324b171b3fc38bf3ee6