### PR TITLE
Enable module scripts in extension manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "description": "Автоматический сбор метрик с Kwork",
   "permissions": ["storage", "alarms", "scripting", "tabs", "downloads"],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "host_permissions": ["https://kwork.ru/manage_kworks*"],
   "action": {
@@ -14,7 +15,8 @@
   "content_scripts": [
     {
       "matches": ["https://kwork.ru/manage_kworks*"],
-      "js": ["content.js"]
+      "js": ["content.js"],
+      "type": "module"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- allow ES module imports in background service worker and content script

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f5c2089488324b55ac17d6d693d69