### PR TITLE
Fix content script import error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,8 +15,7 @@
   "content_scripts": [
     {
       "matches": ["https://kwork.ru/manage_kworks*"],
-      "js": ["content.js"],
-      "type": "module"
+      "js": ["content.js"]
     }
   ]
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,4 +1,11 @@
-import { log } from "./logger";
+// Inline logger to avoid module imports in content script
+async function log(message: string) {
+  console.log(message);
+  if (!chrome?.storage?.local) return;
+  const { logs = [] } = await chrome.storage.local.get(['logs']);
+  logs.push({ time: new Date().toISOString(), message });
+  await chrome.storage.local.set({ logs });
+}
 
 function getMetrics() {
   // More robust selectors for Kwork dashboard


### PR DESCRIPTION
## Summary
- Inline logger in content script to avoid ES module imports
- Load content script as classic script in manifest

## Testing
- `npm run build`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_688f5d53ccd08324bbce6492173355ef